### PR TITLE
aws_autoscaling_instance_refresh - fix fmt/validate checks 

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -4291,12 +4291,12 @@ locals {
   availability_zone_count    = %[1]d
   subnet_count               = %[2]d
   instance_type              = %[3]q
-  use_launch_configuration   = %[4]v
-  use_launch_template        = %[5]v
-  use_mixed_instances_policy = %[6]v
-  use_placement_group        = %[7]v
+  use_launch_configuration   = %[4]t
+  use_launch_template        = %[5]t
+  use_mixed_instances_policy = %[6]t
+  use_placement_group        = %[7]t
   placement_group_name       = %[8]q
-  propagate_at_launch        = %[9]v
+  propagate_at_launch        = %[9]t
 }
 data "aws_ami" "test" {
   most_recent = true

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -4318,12 +4318,12 @@ resource "aws_default_subnet" "current" {
   availability_zone = data.aws_availability_zones.current.names[count.index]
 }
 resource "aws_launch_configuration" "test" {
-  image_id      = "${data.aws_ami.test.id}"
+  image_id      = data.aws_ami.test.id
   instance_type = local.instance_type
 }
 resource "aws_launch_template" "test" {
-  image_id               = data.aws_ami.test.image_id
-  instance_type          = local.instance_type
+  image_id      = data.aws_ami.test.image_id
+  instance_type = local.instance_type
 }
 resource "aws_placement_group" "test" {
   name     = local.placement_group_name

--- a/aws/resource_aws_autoscaling_instance_refresh_test.go
+++ b/aws/resource_aws_autoscaling_instance_refresh_test.go
@@ -223,13 +223,13 @@ func TestAccAWSAutoscalingInstanceRefresh_alreadyOngoing(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(asgName, acctest.RandString(10)),
+				Config: testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(asgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingInstanceRefreshExists(resourceName, &instanceRefresh)),
 			},
 			{
 				Taint:              []string{resourceName},
-				Config:             testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(asgName, acctest.RandString(10)),
+				Config:             testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(asgName),
 				ExpectError:        regexp.MustCompile(`InstanceRefreshInProgress`),
 				ExpectNonEmptyPlan: true,
 			},
@@ -239,7 +239,6 @@ func TestAccAWSAutoscalingInstanceRefresh_alreadyOngoing(t *testing.T) {
 
 func testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(
 	asgName string,
-	trigger string,
 ) string {
 	return composeConfig(
 		testAccAwsAutoscalingInstanceRefreshBase,
@@ -271,12 +270,11 @@ resource "aws_autoscaling_instance_refresh" "test" {
 	wait_for_completion     = false
 
 	triggers = {
-		trigger = %[2]q  
+		token = aws_autoscaling_group.test.instance_refresh_token  
 	}
 }
 `,
 			asgName,
-			trigger,
 		))
 }
 

--- a/aws/resource_aws_autoscaling_instance_refresh_test.go
+++ b/aws/resource_aws_autoscaling_instance_refresh_test.go
@@ -93,51 +93,48 @@ func testAccAwsAutoscalingInstanceRefresh_basic_create(
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
 data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
 }
 
 data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
 }
 
 resource "aws_launch_configuration" "test" {
-	image_id      = data.aws_ami.test.id
-	instance_type = %[2]q
+  image_id      = data.aws_ami.test.id
+  instance_type = %[2]q
 }
 
 resource "aws_autoscaling_group" "test" {
-	name                      = %[1]q
-	availability_zones        = data.aws_availability_zones.current.names
-	min_size                  = 1
-	desired_capacity          = 1
-	max_size                  = 2
-	launch_configuration      = aws_launch_configuration.test.name
-	health_check_grace_period = 5
+  name                      = %[1]q
+  availability_zones        = data.aws_availability_zones.current.names
+  min_size                  = 1
+  desired_capacity          = 1
+  max_size                  = 2
+  launch_configuration      = aws_launch_configuration.test.name
+  health_check_grace_period = 5
 }
 
 resource "aws_autoscaling_instance_refresh" "test" {
-	autoscaling_group_name  = aws_autoscaling_group.test.name
-	min_healthy_percentage  = 50
-	instance_warmup_seconds = 5
-	strategy                = "Rolling"
+  autoscaling_group_name  = aws_autoscaling_group.test.name
+  min_healthy_percentage  = 50
+  instance_warmup_seconds = 5
+  strategy                = "Rolling"
 
-	triggers = {
-		token = aws_autoscaling_group.test.instance_refresh_token
-	}
+  triggers = {
+    token = aws_autoscaling_group.test.instance_refresh_token
+  }
 }
-`,
-			asgName,
-			instanceType,
-		)
+`, asgName, instanceType)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_disappears(t *testing.T) {
@@ -179,50 +176,48 @@ func testAccAwsAutoscalingInstanceRefresh_disappears(
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
 data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
 }
 
 data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
 }
 
 resource "aws_launch_configuration" "test" {
-	image_id      = data.aws_ami.test.id
-	instance_type = "t2.micro"
+  image_id      = data.aws_ami.test.id
+  instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-	name                      = %[1]q
-	availability_zones        = data.aws_availability_zones.current.names
-	min_size                  = 1
-	desired_capacity          = 1
-	max_size                  = 2
-	launch_configuration      = aws_launch_configuration.test.name
-	health_check_grace_period = 5
+  name                      = %[1]q
+  availability_zones        = data.aws_availability_zones.current.names
+  min_size                  = 1
+  desired_capacity          = 1
+  max_size                  = 2
+  launch_configuration      = aws_launch_configuration.test.name
+  health_check_grace_period = 5
 }
 
 resource "aws_autoscaling_instance_refresh" "test" {
-	autoscaling_group_name  = aws_autoscaling_group.test.name
-	min_healthy_percentage  = 50
-	instance_warmup_seconds = 5
-	strategy                = "Rolling"
+  autoscaling_group_name  = aws_autoscaling_group.test.name
+  min_healthy_percentage  = 50
+  instance_warmup_seconds = 5
+  strategy                = "Rolling"
 
-	triggers = {
-		token = aws_autoscaling_group.test.instance_refresh_token
-	}
+  triggers = {
+    token = aws_autoscaling_group.test.instance_refresh_token
+  }
 }
-`,
-			asgName,
-		)
+`, asgName)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_alreadyOngoing(t *testing.T) {
@@ -256,55 +251,53 @@ func testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
 data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
 }
 
 data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
 }
 
 resource "aws_launch_configuration" "test" {
-	image_id      = data.aws_ami.test.id
-	instance_type = "t2.micro" 
+  image_id      = data.aws_ami.test.id
+  instance_type = "t2.micro"
 
-	lifecycle {
-		create_before_destroy = true
-	}
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_group" "test" {
-	name                      = %[1]q
-	availability_zones        = data.aws_availability_zones.current.names
-	min_size                  = 1
-	desired_capacity          = 1
-	max_size                  = 2
-	launch_configuration      = aws_launch_configuration.test.name
-    health_check_grace_period = 5
+  name                      = %[1]q
+  availability_zones        = data.aws_availability_zones.current.names
+  min_size                  = 1
+  desired_capacity          = 1
+  max_size                  = 2
+  launch_configuration      = aws_launch_configuration.test.name
+  health_check_grace_period = 5
 }
 
 resource "aws_autoscaling_instance_refresh" "test" {
-	autoscaling_group_name  = aws_autoscaling_group.test.name
-	min_healthy_percentage  = 0
-	instance_warmup_seconds = 20
-	strategy                = "Rolling"
-	wait_for_completion     = false
+  autoscaling_group_name  = aws_autoscaling_group.test.name
+  min_healthy_percentage  = 0
+  instance_warmup_seconds = 20
+  strategy                = "Rolling"
+  wait_for_completion     = false
 
-	triggers = {
-		token = aws_autoscaling_group.test.instance_refresh_token  
-	}
+  triggers = {
+    token = aws_autoscaling_group.test.instance_refresh_token
+  }
 }
-`,
-			asgName,
-		)
+`, asgName)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_cancelOnTimeout(t *testing.T) {
@@ -360,39 +353,37 @@ func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_create(
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
 data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
 }
 
 data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
 }
 
 resource "aws_launch_configuration" "test" {
-	image_id      = data.aws_ami.test.id
-	instance_type = "t2.micro"
+  image_id      = data.aws_ami.test.id
+  instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-	name                      = %[1]q
-	availability_zones        = data.aws_availability_zones.current.names
-	min_size                  = 1
-	desired_capacity          = 2
-	max_size                  = 2
-	launch_configuration      = aws_launch_configuration.test.name
-	health_check_grace_period = 5
+  name                      = %[1]q
+  availability_zones        = data.aws_availability_zones.current.names
+  min_size                  = 1
+  desired_capacity          = 2
+  max_size                  = 2
+  launch_configuration      = aws_launch_configuration.test.name
+  health_check_grace_period = 5
 }
-`,
-			asgName,
-		)
+`, asgName)
 }
 
 func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_update(
@@ -401,52 +392,50 @@ func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_update(
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
 data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
 }
 
 data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
 }
 
 resource "aws_launch_configuration" "test" {
-	image_id      = data.aws_ami.test.id
-	instance_type = "t2.micro"
+  image_id      = data.aws_ami.test.id
+  instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-	name                      = %[1]q
-	availability_zones        = data.aws_availability_zones.current.names
-	min_size                  = 1
-	desired_capacity          = 2
-	max_size                  = 2
-	launch_configuration      = aws_launch_configuration.test.name
-	health_check_grace_period = 5
+  name                      = %[1]q
+  availability_zones        = data.aws_availability_zones.current.names
+  min_size                  = 1
+  desired_capacity          = 2
+  max_size                  = 2
+  launch_configuration      = aws_launch_configuration.test.name
+  health_check_grace_period = 5
 }
 
 resource "aws_autoscaling_instance_refresh" "test" {
-	autoscaling_group_name  = aws_autoscaling_group.test.name
-	min_healthy_percentage  = 50
-	instance_warmup_seconds = 300
-	strategy                = "Rolling"
+  autoscaling_group_name  = aws_autoscaling_group.test.name
+  min_healthy_percentage  = 50
+  instance_warmup_seconds = 300
+  strategy                = "Rolling"
 
-	triggers = {
-		token = aws_autoscaling_group.test.instance_refresh_token
-	}
+  triggers = {
+    token = aws_autoscaling_group.test.instance_refresh_token
+  }
 
-	timeouts {
-		create = "10s"
-	}
+  timeouts {
+    create = "10s"
+  }
 }
-`,
-			asgName,
-		)
+`, asgName)
 }

--- a/aws/resource_aws_autoscaling_instance_refresh_test.go
+++ b/aws/resource_aws_autoscaling_instance_refresh_test.go
@@ -47,25 +47,6 @@ func testAccCheckAWSAutoScalingInstanceRefreshExists(
 	}
 }
 
-const testAccAwsAutoscalingInstanceRefreshBase = `
-data "aws_ami" "test" {
-	most_recent = true
-	owners      = ["amazon"]
-
-	filter {
-		name   = "name"
-		values = ["amzn-ami-hvm-*-x86_64-gp2"]
-	}
-}
-
-data "aws_availability_zones" "current" {
-	filter {
-		name   = "state"
-		values = ["available"]
-	}
-}
-`
-
 func TestAccAWSAutoscalingInstanceRefresh_basic(t *testing.T) {
 	resourceName := "aws_autoscaling_instance_refresh.test"
 	asgName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -109,9 +90,25 @@ func testAccAwsAutoscalingInstanceRefresh_basic_create(
 	asgName string,
 	instanceType string,
 ) string {
-	return composeConfig(
-		testAccAwsAutoscalingInstanceRefreshBase,
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+		name   = "name"
+		values = ["amzn-ami-hvm-*-x86_64-gp2"]
+	}
+}
+
+data "aws_availability_zones" "current" {
+	filter {
+		name   = "state"
+		values = ["available"]
+	}
+}
+
 resource "aws_launch_configuration" "test" {
 	image_id      = data.aws_ami.test.id
 	instance_type = %[2]q
@@ -140,7 +137,7 @@ resource "aws_autoscaling_instance_refresh" "test" {
 `,
 			asgName,
 			instanceType,
-		))
+		)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_disappears(t *testing.T) {
@@ -179,9 +176,25 @@ func TestAccAWSAutoscalingInstanceRefresh_disappears(t *testing.T) {
 func testAccAwsAutoscalingInstanceRefresh_disappears(
 	asgName string,
 ) string {
-	return composeConfig(
-		testAccAwsAutoscalingInstanceRefreshBase,
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+		name   = "name"
+		values = ["amzn-ami-hvm-*-x86_64-gp2"]
+	}
+}
+
+data "aws_availability_zones" "current" {
+	filter {
+		name   = "state"
+		values = ["available"]
+	}
+}
+
 resource "aws_launch_configuration" "test" {
 	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
@@ -209,7 +222,7 @@ resource "aws_autoscaling_instance_refresh" "test" {
 }
 `,
 			asgName,
-		))
+		)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_alreadyOngoing(t *testing.T) {
@@ -240,9 +253,25 @@ func TestAccAWSAutoscalingInstanceRefresh_alreadyOngoing(t *testing.T) {
 func testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(
 	asgName string,
 ) string {
-	return composeConfig(
-		testAccAwsAutoscalingInstanceRefreshBase,
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+		name   = "name"
+		values = ["amzn-ami-hvm-*-x86_64-gp2"]
+	}
+}
+
+data "aws_availability_zones" "current" {
+	filter {
+		name   = "state"
+		values = ["available"]
+	}
+}
+
 resource "aws_launch_configuration" "test" {
 	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro" 
@@ -275,7 +304,7 @@ resource "aws_autoscaling_instance_refresh" "test" {
 }
 `,
 			asgName,
-		))
+		)
 }
 
 func TestAccAWSAutoscalingInstanceRefresh_cancelOnTimeout(t *testing.T) {
@@ -328,9 +357,25 @@ func TestAccAWSAutoscalingInstanceRefresh_cancelOnTimeout(t *testing.T) {
 func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_create(
 	asgName string,
 ) string {
-	return composeConfig(
-		testAccAwsAutoscalingInstanceRefreshBase,
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+		name   = "name"
+		values = ["amzn-ami-hvm-*-x86_64-gp2"]
+	}
+}
+
+data "aws_availability_zones" "current" {
+	filter {
+		name   = "state"
+		values = ["available"]
+	}
+}
+
 resource "aws_launch_configuration" "test" {
 	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
@@ -347,15 +392,31 @@ resource "aws_autoscaling_group" "test" {
 }
 `,
 			asgName,
-		))
+		)
 }
 
 func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_update(
 	asgName string,
 ) string {
-	return composeConfig(
-		testAccAwsAutoscalingInstanceRefreshBase,
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+		name   = "name"
+		values = ["amzn-ami-hvm-*-x86_64-gp2"]
+	}
+}
+
+data "aws_availability_zones" "current" {
+	filter {
+		name   = "state"
+		values = ["available"]
+	}
+}
+
 resource "aws_launch_configuration" "test" {
 	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
@@ -387,5 +448,5 @@ resource "aws_autoscaling_instance_refresh" "test" {
 }
 `,
 			asgName,
-		))
+		)
 }

--- a/aws/resource_aws_autoscaling_instance_refresh_test.go
+++ b/aws/resource_aws_autoscaling_instance_refresh_test.go
@@ -113,7 +113,7 @@ func testAccAwsAutoscalingInstanceRefresh_basic_create(
 		testAccAwsAutoscalingInstanceRefreshBase,
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-	image_id      = "${data.aws_ami.test.id}"
+	image_id      = data.aws_ami.test.id
 	instance_type = %[2]q
 }
 
@@ -183,7 +183,7 @@ func testAccAwsAutoscalingInstanceRefresh_disappears(
 		testAccAwsAutoscalingInstanceRefreshBase,
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-	image_id      = "${data.aws_ami.test.id}"
+	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
 }
 
@@ -245,7 +245,7 @@ func testAccAwsAutoscalingInstanceRefresh_alreadyOngoing(
 		testAccAwsAutoscalingInstanceRefreshBase,
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-	image_id      = "${data.aws_ami.test.id}"
+	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro" 
 
 	lifecycle {
@@ -334,7 +334,7 @@ func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_create(
 		testAccAwsAutoscalingInstanceRefreshBase,
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-	image_id      = "${data.aws_ami.test.id}"
+	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
 }
 
@@ -359,7 +359,7 @@ func testAccAwsAutoscalingInstanceRefresh_cancelOnTimeout_update(
 		testAccAwsAutoscalingInstanceRefreshBase,
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-	image_id      = "${data.aws_ami.test.id}"
+	image_id      = data.aws_ami.test.id
 	instance_type = "t2.micro"
 }
 


### PR DESCRIPTION
Maybe it will help with: https://github.com/hashicorp/terraform-provider-aws/pull/14442
This PR solve:
- Acceptance Test Linting / terrafmt (pull_request) Failing after 37s — terrafmt
- Acceptance Test Linting / validate-terraform (pull_request) Failing after 2m — validate-terraform

